### PR TITLE
Add Auferet to Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 ## Games
 *Games built on top of GPT3*
 - [AI Dungeon](https://play.aidungeon.io/)
+- [Auferet](https://auferet.com/) - AI game master for solo text adventures and tabletop RPGs with persistent memory and uploadable lore
 - [Learn from Anyone](https://learnfromanyone.com/)
 - [LitRPG](https://www.litrpgadventures.com/)
 


### PR DESCRIPTION
Adds **Auferet** alongside AI Dungeon.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs. It keeps a persistent memory of your story and lets you upload your own lore for a consistent world. It runs on the web and as a published Android app. The entry matches the existing format.
